### PR TITLE
fixed for comments nested inside selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function(map) {
     // map vars
     visit(style, function(declarations, node){
       declarations.forEach(function(decl){
-        if (0 != decl.property.indexOf('var-')) return;
+        if (!decl.property || 0 != decl.property.indexOf('var-')) return;
         var name = decl.property.replace('var-', '');
         map[name] = decl.value;
       });
@@ -49,7 +49,7 @@ module.exports = function(map) {
     // substitute values
     visit(style, function(declarations, node){
       declarations.forEach(function(decl){
-        if (!decl.value.match(/\bvar\(/)) return;
+        if (!decl.value || !decl.value.match(/\bvar\(/)) return;
         decl.value = replace(decl.value);
       });
     });


### PR DESCRIPTION
basically if you have a situation like this:

``` css
.logo {
  position: relative;
  display: inline-block;
  vertical-align: middle; /* not baseline, so we align up _and_ down */
  height: 1em; /* keep height constant regardless of innards */
  margin: 0; /* reset */
}
```

the comments will show up in the declarations, dunno if you want to fix this here or in `rework-visit` instead.

also seems like there's a newer version on npm then on github? so you might need to push and i might need to rebase before this gets merged in
