### PR TITLE
Fix persistent vars map

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,11 @@ var visit = require('rework-visit');
  * Module export.
  */
 
-module.exports = function(map){
-  map = map || {};
+module.exports = function(jsmap) {
 
   return function vars(style){
+    var map = jsmap || {};
+
     // define variables
     style.rules.forEach(function (rule) {
       var i;


### PR DESCRIPTION
The module was not clearing out the variables map between function calls.

Would appreciate a sanity check, in case I've missed the reason why it was originally done like this.

cc @ianstormtaylor @anthonyshort
